### PR TITLE
[Linux] Fix retrieval of audio level by querying the default device

### DIFF
--- a/lemontify
+++ b/lemontify
@@ -112,9 +112,9 @@ function kbdlight_icon() {
 # requires: pulseaudio libpulse					#
 #################################################
 function Linux_audio_get() {
-	#pactl list sinks | grep '^[[:space:]]Volume:' | head -n $(( $SINK + 1 )) |\
-	pactl list sinks | grep '^[[:space:]]Volume:' | head -n 1 |\
-		tail -n 1 | sed -e 's,.* \([0-9][0-9]*\)%.*,\1,'
+    pacmd list-sinks | grep -A 15 '\* index' | grep 'volume:' |\
+    grep -v 'base volume:' | awk -F : '{print $3}' | grep -oP '.{0,3}%' |\
+    sed s/.$// | tr -d ' '
 }
 
 function Linux_audio_status() {


### PR DESCRIPTION
**Problem:** On linux, the retrieval of current audio is not working properly when multiple audio sinks are connected. The current implementation fetches the first sink it finds through `pactl list sinks` and `grep`s on that sink to retrieve the audio. If you add a new audio sink, like a bluetooth speaker, it will create a new entry in the sinks list that will be shown after the existing ones. Although you will likely play audio from your newly added sink, lemontify will keep querying the first sink in the list, which might not be the one that is playing audio.

**Solution:** This change addresses the problem by relying on the *default* sink (shown as 'Fallback sink' in pavucontrol).

**Extras:** My knowledge on pulseaudio is not that extensive, but I would say that a *default* sink might not be the one that is currently playing audio. Also, you might have multiple sinks playing audio at the same time.
So this solution is not perfect, but, as far as I tested, newly added sinks are set as "default" automatically by pulseaudio, so it will likely work for most of the situations where a simple audio setup is present, but it will probably have issues with more complex audio setups.